### PR TITLE
feat: Breakout experience improvements

### DIFF
--- a/src/channels/breakout/components/Donation.tsx
+++ b/src/channels/breakout/components/Donation.tsx
@@ -1,0 +1,61 @@
+import styled from '@emotion/styled';
+import { FormattedDonation } from '@gdq/types/tracker';
+import gsap from 'gsap';
+import { FC, useLayoutEffect, useRef } from 'react';
+import { Color, toCss } from '../game/model';
+
+interface Props {
+	readonly donation: FormattedDonation;
+	readonly offset: number;
+}
+
+const Donation: FC<Props> = ({ donation, offset }: Props) => {
+	const text = useRef<HTMLDivElement>(null);
+
+	useLayoutEffect(() => {
+		const color = toCss(colorForAmount(donation.rawAmount));
+
+		// basically logarithmic.
+		const scale = Math.min(2, Math.max(0.8, Math.log10(donation.rawAmount) ** (1 / 3)));
+
+		gsap.timeline()
+			.to(text.current, {
+				y: 0,
+				scale,
+				opacity: 1,
+				color,
+			})
+			.to(text.current, { opacity: 0 }, 2);
+	}, []);
+
+	useLayoutEffect(() => {
+		gsap.to(text.current, { y: offset * 50 });
+	}, [offset]);
+
+	return <DonationText ref={text}>{donation.amount}</DonationText>;
+};
+
+const DonationText = styled.div`
+	font-family: gdqpixel;
+	color: #eee;
+	font-size: 25px;
+
+	position: absolute;
+	left: 0;
+	transform: translateX(-50%) scale(0);
+	opacity: 0;
+`;
+
+function colorForAmount(amount: number): Color {
+	if (amount >= 500) {
+		return Color.YELLOW;
+	}
+
+	if (amount >= 50) {
+		return Color.GREEN;
+	}
+
+	return Color.WHITE;
+}
+
+export default Donation;

--- a/src/channels/breakout/components/SuperTweenNumber.tsx
+++ b/src/channels/breakout/components/SuperTweenNumber.tsx
@@ -1,0 +1,23 @@
+import { useIncrementNumber } from '@gdq/lib/hooks/useIncrementNumber';
+import { FC } from 'react';
+
+interface Props {
+	readonly value?: number;
+	readonly letterColors: string[];
+}
+
+const SuperTweenNumber: FC<Props> = (props) => {
+	const number = useIncrementNumber(props.value ?? 0);
+
+	return (
+		<>
+			{['$', ...number.toLocaleString('en-US', { maximumFractionDigits: 0 })].map((letter, i) => (
+				<span key={i} style={{ color: props.letterColors[i % props.letterColors.length] }}>
+					{letter}
+				</span>
+			))}
+		</>
+	);
+};
+
+export default SuperTweenNumber;

--- a/src/channels/breakout/game/math.ts
+++ b/src/channels/breakout/game/math.ts
@@ -54,3 +54,14 @@ export function collisionBox(block: Block): Bounds {
 		height: block.height + 2 * block.collisionBuffer,
 	};
 }
+
+export function shuffleCopy<T>(arr: readonly T[]): T[] {
+	const result = [...arr];
+
+	for (let i = result.length - 1; i > 0; i--) {
+		const j = 0 | (Math.random() * (i + 1));
+		[result[i], result[j]] = [result[j], result[i]];
+	}
+
+	return result;
+}

--- a/src/channels/breakout/game/model.ts
+++ b/src/channels/breakout/game/model.ts
@@ -44,6 +44,14 @@ export enum Color {
 	LIGHT_GRAY = 0x181818,
 }
 
+export function toCss(color: Color): string {
+	const red = (color >> 16) & 0xff;
+	const green = (color >> 8) & 0xff;
+	const blue = color & 0xff;
+
+	return `rgb(${red} ${green} ${blue})`;
+}
+
 export enum Side {
 	TOP = 'top',
 	RIGHT = 'right',


### PR DESCRIPTION
### Description

Makes some improvements to the Breakout channel to add more "fun."

* Shows donation amount (scaled/colored based on donation magnitude) when a donation is received
* Adds 10 balls (instead of one) when a donation of >$500 is received
* Adds more fun to the victory experience (colorizes the donation total)

Demo showing the ability to handle rapid donations (a/k/a $5 trains):

https://github.com/GamesDoneQuick/gdq-break-channels/assets/306088/e20326ae-abb0-4e38-b506-740ea429b731

Demo showing various donation amounts and the upgraded victory experience:

https://github.com/GamesDoneQuick/gdq-break-channels/assets/306088/8747824f-447f-48ce-92cc-013a51f887ca

### Checklist:

- [X] I have read and followed the requirements in the [**Contributing** document](https://github.com/GamesDoneQuick/gdq-break-channels/blob/main/CONTRIBUTING.md).
- [X] My code has been tested.
- [X] My commit title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) formatting.
- [X] All the code is my own, or is code I have the rights to, and is being made available under the [Apache License Version 2.0](https://www.apache.org/licenses/LICENSE-2.0).
