### PR TITLE
fix: Fix y-axis margins on FF shop

### DIFF
--- a/src/channels/ff-shop/index.tsx
+++ b/src/channels/ff-shop/index.tsx
@@ -81,7 +81,7 @@ export function FFMenu(props: ChannelProps) {
 					</Row>
 					<Row>
 						<MenuCard gradient={theme.current.gradient} style={{ padding: '0' }}>
-							<Row style={{ padding: '8px 0px 8px 56px' }}>
+							<Row style={{ paddingLeft: '56px' }}>
 								<Column style={{ flexDirection: 'column-reverse', alignSelf: 'center', height: '92%' }}>
 									{currentShopItems.value != undefined &&
 										currentShopItems.value.map((item, i) => (


### PR DESCRIPTION
### Description
- Fixes the y-axis margins of the shop menu.
- This was very hard to see, but you can barely make out that the scrollbar doesn't fill the entire height, and the cursor does not line up with the bottom item (see red in screenshot below)
- This was leftover padding and did not show up during testing. **If possible, can someone tell me which browser is used during the events, so I can better test styling?**

![image](https://github.com/GamesDoneQuick/gdq-break-channels/assets/6615820/40fe39eb-f5ce-4d25-83cc-3782146b49d1)


### Checklist:
- [x] I have read and followed the requirements in the [**Contributing** document](https://github.com/GamesDoneQuick/gdq-break-channels/blob/main/CONTRIBUTING.md).
- [x] My code has been tested.
- [x] My commit title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) formatting.
- [x] All the code is my own, or is code I have the rights to, and is being made available under the [Apache License Version 2.0](https://www.apache.org/licenses/LICENSE-2.0).
