### PR TITLE
fix(papers-please): Animations resetting on return

### DIFF
--- a/src/channels/papers-please/index.tsx
+++ b/src/channels/papers-please/index.tsx
@@ -67,6 +67,8 @@ const citationTexts: string[] = [
 	'Sequence Breaking',
 	'Dropped your combo',
 	'Didn\'t say "Yes Chef".',
+	'Weeeeeeeeeeeeeeeeee!',
+	'BINGO!'
 ];
 
 export function PapersPlease(props: ChannelProps) {
@@ -197,6 +199,8 @@ export function PapersPlease(props: ChannelProps) {
 	});
 
 	useEffect(() => {
+		setAmountLocked(goalAmount);
+		setAnimationPlaying(true);
 		setTimeout(() => {
 			appear();
 		}, 2000);


### PR DESCRIPTION
<!--- Please fill out the following template. -->
<!--- Do not remove the template -->

### Description
<!--- Explain what your change adds/or fixes. -->
<!--- If your change is a new channel, explain what it does and how it responds to different events. Please include a screenshot and/or (preferably) a video -->
<!--- If your change adds any new dependencies or has any special requirements for being ran, such as a connection to an external service, please make a note of those additions/requirements and why they are necessary. -->
* Fixes animations playing in the incorrect order when changing back to the Papers Please channel from another, particularly when goals (@ every 1k raised) are met while not rendered, by locking animations on initial render.
* 2 more bonus citation lines
### Checklist:
<!--- Add an `x` to the boxes once you've confirmed them. -->
- [x] I have read and followed the requirements in the [**Contributing** document](https://github.com/GamesDoneQuick/gdq-break-channels/blob/main/CONTRIBUTING.md).
- [x] My code has been tested.
- [x] My commit title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) formatting.
- [x] All the code is my own, or is code I have the rights to, and is being made available under the [Apache License Version 2.0](https://www.apache.org/licenses/LICENSE-2.0).