### PR TITLE
fix: Update tsconfig and fix qwop types for consumption in bundlers

### DIFF
--- a/src/channels/qwop/qwop-guy.ts
+++ b/src/channels/qwop/qwop-guy.ts
@@ -232,7 +232,13 @@ export function usePhysicsBody(
 	useEffect(() => {
 		if (!box2d || !world || !recordLeak) return;
 
-		const createBody = (key: string, x: number, y: number, angle: number, densityMultiplier = 1) => {
+		const createBody = (
+			key: keyof typeof qwopSheet.frames,
+			x: number,
+			y: number,
+			angle: number,
+			densityMultiplier = 1,
+		) => {
 			const spriteDef = qwopSheet.frames[key];
 			const sourceSize = spriteDef.sourceSize;
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,22 +1,21 @@
 {
 	"compilerOptions": {
 		"target": "es2020",
-		"baseUrl": ".",
 		"outDir": "dist",
 		"jsx": "react-jsx",
 		"jsxImportSource": "@emotion/react",
 		"lib": ["dom", "webworker", "es2019"],
-		"module": "ES2020",
-		"moduleResolution": "node",
+		"module": "preserve",
+		"moduleResolution": "bundler",
 		"strict": true,
 		"esModuleInterop": true,
 		"allowSyntheticDefaultImports": true,
 		"skipLibCheck": true,
 		"paths": {
-			"@gdq/*": ["src/*"]
+			"@gdq/*": ["./src/*"]
 		},
 		"declaration": true,
 		"types": ["@nodecg/types/augment-window", "obs-studio"]
 	},
-	"include": ["src/**/*.ts", "src/**/*.tsx", "index.tsx"]
+	"include": ["./src/**/*.ts", "./src/**/*.tsx", "./index.tsx"]
 }


### PR DESCRIPTION
<!--- Please fill out the following template. -->
<!--- Do not remove the template -->

### Description

TypeScript was configured with `moduleResolution: node`, which [is explicitly discouraged](https://www.typescriptlang.org/docs/handbook/modules/reference.html#node10-formerly-known-as-node), failed to resolve a number of files for typechecking due to the resolution behavior, and is also inaccurate for the project since the files are consumed in a browser context (i.e., nodecg graphics) rather than in Node.

When fixing the TypeScript configuration in a project consuming this package, it revealed this diagnostic:
<img width="735" height="198" alt="image" src="https://github.com/user-attachments/assets/f5df7c68-a4d3-4073-a311-e5fbad02388f" />
 which was undiscovered in this package specifically because of the `node` module resolution resolving the `.json` import to `any` rather than a typed object.

Working backwards from there, and to fix the issues described in the first paragraph, this PR changes the typescript module mode to `preserve/bundler`, which is the established standard for frontend/bundled projects nowadays and matches the intended usage of this project. It also properly resolves JSON imports with detailed types, and brings the diagnostic from above into this project.

The solution here is easy enough, just restricting the parameter type to keys of the object in the first place. Downstream, this should resolve type issues in consuming packages that have to typecheck this library because it is distributed as un-transpiled typescript.


<!--- Explain what your change adds/or fixes. -->
<!--- If your change is a new channel, explain what it does and how it responds to different events. Please include a screenshot and/or (preferably) a video -->
<!--- If your change adds any new dependencies or has any special requirements for being ran, such as a connection to an external service, please make a note of those additions/requirements and why they are necessary. -->

### Checklist:
<!--- Add an `x` to the boxes once you've confirmed them. -->
- [x] I have read and followed the requirements in the [**Contributing** document](https://github.com/GamesDoneQuick/gdq-break-channels/blob/main/CONTRIBUTING.md).
- [x] My code has been tested.
- [x] My commit title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) formatting.
- [x] All the code is my own, or is code I have the rights to, and is being made available under the [Apache License Version 2.0](https://www.apache.org/licenses/LICENSE-2.0).
