### PR TITLE
Increase width of Balatro score column

### DIFF
--- a/src/channels/balatro/index.tsx
+++ b/src/channels/balatro/index.tsx
@@ -296,7 +296,7 @@ const LiquifiedTextWrapper = styled.div`
 
 const LeftBar = styled.div`
 	position: absolute;
-	width: 20%;
+	width: 23%;
 	height: 100%;
 	background-color: rgb(41, 51, 52);
 	left: 2%;


### PR DESCRIPTION
<!--- Please fill out the following template. -->
<!--- Do not remove the template -->

### Description
<!--- Explain what your change adds/or fixes. -->
<!--- If your change is a new channel, explain what it does and how it responds to different events. Please include a screenshot and/or (preferably) a video -->
<!--- If your change adds any new dependencies or has any special requirements for being ran, such as a connection to an external service, please make a note of those additions/requirements and why they are necessary. -->

Increases the width of the score column to support up to 9 digit totals.

I think a fun add would be scientific notation for large numbers (ie 3.442e6) to mimic the game further, but I leave that final decision to you guys. This PR at least fixes things for AGDQ2026.

<img width="1306" height="394" alt="Screenshot 2026-01-06 164300" src="https://github.com/user-attachments/assets/d6e867b6-02fb-45c8-8896-ede39f055a9f" />

<img width="1310" height="394" alt="Screenshot 2026-01-06 164324" src="https://github.com/user-attachments/assets/34132629-06c7-47d9-a918-bee81d5cee0e" />


### Checklist:
<!--- Add an `x` to the boxes once you've confirmed them. -->
- [x] I have read and followed the requirements in the [**Contributing** document](https://github.com/GamesDoneQuick/gdq-break-channels/blob/main/CONTRIBUTING.md).
- [x] My code has been tested.
- [x] My commit title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) formatting.
- [x] All the code is my own, or is code I have the rights to, and is being made available under the [Apache License Version 2.0](https://www.apache.org/licenses/LICENSE-2.0).

<!-- If your change is for a new channel, uncomment and check the following -->
<!--
- [ ] My channel contains no first-party Nintendo assets.
- [ ] I understand that GamesDoneQuick may reject, make changes to, or choose not to show this channel on broadcast, and that discussion or merging does not guarantee the work will be used.
-->
